### PR TITLE
Travis CI configured for testing release updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+#
+# check https://config.travis-ci.com
+# for the list of available modules 
+# for the travis YAML build config files
+#
+
+# set linux and osx as the list of
+# build environments
+# https://config.travis-ci.com/ref/os
+# https://docs.travis-ci.com/user/reference/overview/
+os: 
+- linux
+- osx
+
+# set amd64 as the architecture for the build
+# https://config.travis-ci.com/ref/arch
+arch: amd64
+
+# execute the following stages in the
+# order mentioned if the branch name 
+# is ci-build
+stages:
+  - configure
+  - analysis
+  - name: deploy
+    if: branch = ci-build
+
+# definition of the stages
+jobs:
+  include:
+    - stage: configure
+      script: bash scripts/travis-configure.sh
+    - stage: analysis
+      script: bash scripts/travis-analysis.sh

--- a/scripts/travis-analysis.sh
+++ b/scripts/travis-analysis.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+echo
+echo 'performing the analysis and building output...'
+echo
+./project make 1> ../output-analysis.log
+
+# END

--- a/scripts/travis-configure.sh
+++ b/scripts/travis-configure.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+# create the required directories
+echo
+echo 'creating build, input, and software directrorie...'
+echo
+mkdir -p ../build \
+         ../input \
+         ../software
+
+echo
+echo 'building software required for the project...'
+echo
+if [ "x$TRAVIS_OS_NAME" = xlinux ]; then
+    ./project configure \
+              --build-dir=../build \
+              --input-dir=../input \
+              --software-dir=../software \
+              --all-highlevel 1> ../output-configure.log
+fi
+
+if [ "x$TRAVIS_OS_NAME" = xosx ]; then
+    ./project configure \
+              --build-dir=../build \
+              --input-dir=../input \
+              --software-dir=../software 1> ../output-analysis.log
+fi
+
+# END


### PR DESCRIPTION
Until now, the task of testing successful build of maneage with new software
updates was done by manually running project scripts in different
virtual/contained environments.

Travis CI is an automation system for testing and deploying Open Source
projects hosted on GitHub and BitBucket. Currently, Travis provides several
Ubuntu distros as well as macosx and Windows as test environments.

With this commit, we have configured Travis to initiate an automated build
of maneage by running two scripts at two stages: configure and analysis,
when a new commit is pushed into the ci-build branch.